### PR TITLE
Pauli numeric computation interop

### DIFF
--- a/src/C1.jl
+++ b/src/C1.jl
@@ -2,43 +2,39 @@
 
 export localclifford
 
-const pX = [0 1; 1 0]
-const pY = [0 -im; im 0]
-const pZ = [1 0; 0 -1]
-
 C1 = Vector{Clifford{1}}(24)
 
 # identity
 C1[1]  = RI
 
 # pi/2 and pi rotations about X,Y,Z
-C1[2]  = expm(-im*pi/4*pX)
-C1[3]  = im * pX
-C1[4]  = expm(im*pi/4*pX)
-C1[5]  = expm(-im*pi/4*pY)
-C1[6]  = im * pY
-C1[7]  = expm(im*pi/4*pY)
-C1[8]  = expm(-im*pi/4*pZ)
-C1[9]  = im * pZ
-C1[10] = expm(im*pi/4*pZ)
+C1[2]  = expm(-im*pi/4*X)
+C1[3]  = im * X
+C1[4]  = expm(im*pi/4*X)
+C1[5]  = expm(-im*pi/4*Y)
+C1[6]  = im * Y
+C1[7]  = expm(im*pi/4*Y)
+C1[8]  = expm(-im*pi/4*Z)
+C1[9]  = im * Z
+C1[10] = expm(im*pi/4*Z)
 
 # Hadamard class
-C1[11] = expm(-im*pi/2/sqrt(2) * (pX+pY))
-C1[12] = expm(-im*pi/2/sqrt(2) * (pX-pY))
-C1[13] = expm(-im*pi/2/sqrt(2) * (pX+pZ)) # standard Hadamard
-C1[14] = expm(-im*pi/2/sqrt(2) * (pX-pZ))
-C1[15] = expm(-im*pi/2/sqrt(2) * (pY+pZ))
-C1[16] = expm(-im*pi/2/sqrt(2) * (pY-pZ))
+C1[11] = expm(-im*pi/2/sqrt(2) * (X+Y))
+C1[12] = expm(-im*pi/2/sqrt(2) * (X-Y))
+C1[13] = expm(-im*pi/2/sqrt(2) * (X+Z)) # standard Hadamard
+C1[14] = expm(-im*pi/2/sqrt(2) * (X-Z))
+C1[15] = expm(-im*pi/2/sqrt(2) * (Y+Z))
+C1[16] = expm(-im*pi/2/sqrt(2) * (Y-Z))
 
 # Axis exchange class
-C1[17] = expm(-1im*pi/3/sqrt(3) * (pX+pY+pZ))
-C1[18] = expm(-2im*pi/3/sqrt(3) * (pX+pY+pZ))
-C1[19] = expm(-1im*pi/3/sqrt(3) * (pX-pY+pZ))
-C1[20] = expm(-2im*pi/3/sqrt(3) * (pX-pY+pZ))
-C1[21] = expm(-1im*pi/3/sqrt(3) * (pX+pY-pZ))
-C1[22] = expm(-2im*pi/3/sqrt(3) * (pX+pY-pZ))
-C1[23] = expm(-1im*pi/3/sqrt(3) * (-pX+pY+pZ))
-C1[24] = expm(-2im*pi/3/sqrt(3) * (-pX+pY+pZ))
+C1[17] = expm(-1im*pi/3/sqrt(3) * (X+Y+Z))
+C1[18] = expm(-2im*pi/3/sqrt(3) * (X+Y+Z))
+C1[19] = expm(-1im*pi/3/sqrt(3) * (X-Y+Z))
+C1[20] = expm(-2im*pi/3/sqrt(3) * (X-Y+Z))
+C1[21] = expm(-1im*pi/3/sqrt(3) * (X+Y-Z))
+C1[22] = expm(-2im*pi/3/sqrt(3) * (X+Y-Z))
+C1[23] = expm(-1im*pi/3/sqrt(3) * (-X+Y+Z))
+C1[24] = expm(-2im*pi/3/sqrt(3) * (-X+Y+Z))
 
 rC1 = Dict{Clifford{1},UInt}()
 

--- a/src/Cliffords.jl
+++ b/src/Cliffords.jl
@@ -116,7 +116,7 @@ function *(c::Clifford, p::Pauli)
     G = generators(p)
     r = paulieye(length(p))
     for g in G
-        r *= phase(g) * c.T[abs(g)]
+        r *= phase(g) ∘ c.T[abs(g)]
     end
     return r
 end
@@ -128,7 +128,7 @@ function \(c::Clifford, p::Pauli)
     G = generators(p)
     r = paulieye(length(p))
     for g in G
-        r *= phase(g) * c.Tinv[abs(g)]
+        r *= phase(g) ∘ c.Tinv[abs(g)]
     end
     return r
 end

--- a/src/Paulis.jl
+++ b/src/Paulis.jl
@@ -1,6 +1,6 @@
 import Base.complex
 
-export Pauli, Id, X, Y, Z, allpaulis, paulieye, weight, complex
+export Pauli, Id, X, Y, Z, allpaulis, paulieye, weight, complex, ∘
 
 # Paulis's are represented by an immutable vector of numbers (0-3) corresponding to
 # single-qubit Paulis, along with a phase parameter.
@@ -65,7 +65,7 @@ function convert{N}(::Type{Pauli{N}}, m::Matrix)
     for p in allpaulis(n)
         overlap = trace(m*convert(typeof(complex(m)),p)) / d
         if isapprox(abs(overlap),1,atol=d*eps(Float64))
-            return (round(real(overlap))+im*round(imag(overlap)))*p
+            return (round(real(overlap))+im*round(imag(overlap)))∘p
         elseif !isapprox(abs(overlap),0,atol=d*eps(Float64))
             error("Trying to convert non-Pauli matrix to a Pauli object")
         end
@@ -96,17 +96,30 @@ levicivita(a, b) = mapreduce(levicivita, +, zip(a,b))
 
 const phases_ = [1, im, -1, -im]
 
-function *(n::Number, p::Pauli)
+# special "multiplication" operator that returns a Pauli
+function ∘(n::Number, p::Pauli)
     ns = findfirst(n .== phases_) - 1
     @assert(ns >= 0, "Multiplication only supported for +/- 1, +/- im")
     Pauli(p.v, mod(p.s + ns,4))
 end
+
+# unary operators return Paulis
++(p::Pauli) = p
+-(p::Pauli) = Pauli(p.v, p.s + 0x02)
+
+# standard binary operators are defined to return Matrix
+*(n::Number, p::Pauli) = n * complex(p)
 *(p::Pauli, n::Number) = n * p
 *(p::Pauli, u::Matrix) = *(promote(p, u)...)
 *(u::Matrix, p::Pauli) = *(promote(u, p)...)
 
-+(p::Pauli) = p
--(p::Pauli) = Pauli(p.v, p.s + 0x02)
++(p::Pauli, u::Matrix) = +(promote(p, u)...)
++(u::Matrix, p::Pauli) = +(promote(p, u)...)
++(a::Pauli, b::Pauli) = complex(a) + complex(b)
+
+-(p::Pauli, u::Matrix) = -(promote(p, u)...)
+-(u::Matrix, p::Pauli) = -(promote(p, u)...)
+-(a::Pauli, b::Pauli) = complex(a) - complex(b)
 
 abs(p::Pauli) = Pauli(p.v, 0)
 phase(p::Pauli) = phases_[p.s+1]
@@ -127,7 +140,7 @@ end
 function generators(a::Pauli{1})
     if abs(a) == Y
         #println(Pauli[im*phase(a)*X,Z])
-        return Pauli[im*phase(a)*X,Z]
+        return Pauli[im*phase(a)∘X,Z]
     else
         #println(Pauli[a])
         return Pauli[a]
@@ -151,7 +164,8 @@ function generators{N}(a::Pauli{N})
             push!(G, expand(Z, [idx], N))
         end
     end
-    G[1] *= s # give phase to first generator
+    # give phase to first generator
+    G[1] = s ∘ G[1]
     return G
 end
 

--- a/test/testpaulis.jl
+++ b/test/testpaulis.jl
@@ -8,10 +8,10 @@
 @test Y * Y == Id
 @test Z * Z == Id
 
-@test X * Y == im*Z
-@test Y * Z == im*X
-@test Z * X == im*Y
-@test Y * X == -im*Z
+@test X * Y == im∘Z
+@test Y * Z == im∘X
+@test Z * X == im∘Y
+@test Y * X == -im∘Z
 
 @test Id < X
 @test X < Y
@@ -29,12 +29,12 @@
 # generators
 @test generators(X) == [X]
 @test generators(Z) == [Z]
-@test generators(Y) == [im*X, Z]
+@test generators(Y) == [im∘X, Z]
 
 @test generators(XX) == [XI, IX]
 @test generators(ZZ) == [ZI, IZ]
-@test generators(XY) == [im*XI, IX, IZ]
-@test generators(YX) == [im*XI, ZI, IX]
+@test generators(XY) == [im∘XI, IX, IZ]
+@test generators(YX) == [im∘XI, ZI, IX]
 @test generators(YY) == [-XI, ZI, IX, IZ]
 
 XII = kron(X,Id,Id)
@@ -46,7 +46,7 @@ IIZ = kron(Id,Id,Z)
 
 @test generators(kron(X,X,X)) == [XII, IXI, IIX]
 @test generators(kron(Z,Z,Z)) == [ZII, IZI, IIZ]
-@test generators(kron(X,Y,Z)) == [im*XII, IXI, IZI, IIZ]
+@test generators(kron(X,Y,Z)) == [im∘XII, IXI, IZI, IIZ]
 
 @test Pauli([1 0; 0 1]) == Id
 @test Pauli([0 1; 1 0]) == X
@@ -67,6 +67,6 @@ for i=1:20
 end
 
 #
-@test_approx_eq norm(complex(X)-[0 1; 1 0]) 0
-@test_approx_eq norm(complex(Y)-[0 -1im;1im 0]) 0
-@test_approx_eq norm(complex(Z)-[1 0; 0 -1]) 0
+@test_approx_eq norm(X - [0 1; 1 0]) 0
+@test_approx_eq norm(Y - [0 -1im;1im 0]) 0
+@test_approx_eq norm(Z - [1 0; 0 -1]) 0


### PR DESCRIPTION
Introduces the `∘` operator for `Number` times `Pauli` returning a `Pauli`. The standard multiplication operator returns a `Matrix`. This allows us to also define addition and subtraction of `Pauli`s to return `Matrix`. I *think* this is sufficient for most things we want to do. Let me know if there are other useful operations to define.

cc @caryan @marcusps 