### PR TITLE
Fix for julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 julia:
   - 0.7
+  - 1.0
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7-alpha
+julia 0.7
 StaticArrays

--- a/src/C1.jl
+++ b/src/C1.jl
@@ -2,7 +2,7 @@
 
 export localclifford
 
-C1 = Vector{Clifford{1}}(24)
+C1 = Vector{Clifford{1}}(undef, 24)
 
 # identity
 C1[1]  = RI


### PR DESCRIPTION
This is incomplete; there are still some issues with `expand` (e.g. `expand(X)` raises a MethodError)