### PR TITLE
REQUIRE -> Project.toml and roll everything to Julia 1.0 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: julia
 julia:
-  - 0.7
   - 1.0
+  - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,7 @@
 name = "Cliffords"
 uuid = "276b0191-6968-5de0-98fd-2a81b0f3910d"
+authors = ["Marcus P da Silva", "Blake Johnson", "Matthew Ware", "Guilhem Ribeill"]
+version = "0.6.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "Cliffords"
+uuid = "276b0191-6968-5de0-98fd-2a81b0f3910d"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+julia = "1"
+
+[extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["LinearAlgebra", "Test"]

--- a/README.md
+++ b/README.md
@@ -31,12 +31,3 @@ H * Z => X
 CNOT21 = expand(CNOT, [2,1], 2)
 CNOT * CNOT21 * CNOT == SWAP => true
 ```
-
-## Installation 
-For Julia v0.6 run:
-
-```julia> Pkg.add("Cliffords")```
-
-For v0.7 and above, run the following in the package manager to grab the master branch:
-
-```(v1.1) pkg> add Cliffords#master```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-StaticArrays


### PR DESCRIPTION
I think it's safe to roll to Julia 1.0 world and then we can release this as `v0.6` which will make it easier to use `QuantumInfo.jl`